### PR TITLE
chore(deps-dev): bump fast-xml-parser to 5.5.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,23 +14,23 @@ Run `yarn benchmark`
 ### Node.js v20.20.1
 
 ```console
-fast-xml-parser@5.5.6 x 72.18 ops/sec ±2.00% (76 runs sampled)
-xmldom@0.8.11 x 127 ops/sec ±1.18% (82 runs sampled)
+fast-xml-parser@5.5.6 x 36.91 ops/sec ±6.18% (52 runs sampled)
+xmldom@0.8.11 x 58.57 ops/sec ±7.39% (63 runs sampled)
 Fastest is xmldom@0.8.11
 ```
 
 ### Node.js v22.22.1
 
 ```console
-fast-xml-parser@5.5.6 x 77.66 ops/sec ±1.13% (68 runs sampled)
-xmldom@0.8.11 x 136 ops/sec ±0.57% (86 runs sampled)
+fast-xml-parser@5.5.6 x 37.80 ops/sec ±1.05% (63 runs sampled)
+xmldom@0.8.11 x 71.73 ops/sec ±1.27% (73 runs sampled)
 Fastest is xmldom@0.8.11
 ```
 
 ### Node.js v24.14.0
 
 ```console
-fast-xml-parser@5.5.6 x 79.36 ops/sec ±1.03% (70 runs sampled)
-xmldom@0.8.11 x 148 ops/sec ±0.42% (85 runs sampled)
+fast-xml-parser@5.5.6 x 39.94 ops/sec ±2.85% (54 runs sampled)
+xmldom@0.8.11 x 79.24 ops/sec ±1.66% (69 runs sampled)
 Fastest is xmldom@0.8.11
 ```

--- a/README.md
+++ b/README.md
@@ -11,26 +11,26 @@ Benchmarks parsing time between different XML Parsers from npm
 
 Run `yarn benchmark`
 
-### Node.js v20.19.5
+### Node.js v20.20.1
 
 ```console
-fast-xml-parser@5.2.5 x 43.18 ops/sec ±5.42% (58 runs sampled)
-xmldom@0.8.11 x 64.09 ops/sec ±8.80% (70 runs sampled)
+fast-xml-parser@5.5.6 x 72.18 ops/sec ±2.00% (76 runs sampled)
+xmldom@0.8.11 x 127 ops/sec ±1.18% (82 runs sampled)
 Fastest is xmldom@0.8.11
 ```
 
-### Node.js v22.19.0
+### Node.js v22.22.1
 
 ```console
-fast-xml-parser@5.2.5 x 49.80 ops/sec ±1.41% (64 runs sampled)
-xmldom@0.8.11 x 75.12 ops/sec ±0.46% (77 runs sampled)
+fast-xml-parser@5.5.6 x 77.66 ops/sec ±1.13% (68 runs sampled)
+xmldom@0.8.11 x 136 ops/sec ±0.57% (86 runs sampled)
 Fastest is xmldom@0.8.11
 ```
 
-### Node.js v24.8.0
+### Node.js v24.14.0
 
 ```console
-fast-xml-parser@5.2.5 x 48.09 ops/sec ±5.57% (65 runs sampled)
-xmldom@0.8.11 x 80.06 ops/sec ±0.56% (69 runs sampled)
+fast-xml-parser@5.5.6 x 79.36 ops/sec ±1.03% (70 runs sampled)
+xmldom@0.8.11 x 148 ops/sec ±0.42% (85 runs sampled)
 Fastest is xmldom@0.8.11
 ```

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ const fileNamePath = join(__dirname, "data", "sample.xml");
 const xmlData = readFileSync(fileNamePath).toString();
 
 const suite = new benchmark.Suite();
-const fastXmlParser = new XMLParser();
+const fastXmlParser = new XMLParser({ processEntities: false });
 const domParser = new DOMParser();
 
 const fastXmlParserVersion = JSON.parse(

--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
   "dependencies": {
     "@xmldom/xmldom": "^0.8.11",
     "benchmark": "^2.1.4",
-    "fast-xml-parser": "^5.2.5"
+    "fast-xml-parser": "^5.5.6"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -18,7 +18,7 @@ __metadata:
   dependencies:
     "@xmldom/xmldom": "npm:^0.8.11"
     benchmark: "npm:^2.1.4"
-    fast-xml-parser: "npm:^5.2.5"
+    fast-xml-parser: "npm:^5.5.6"
   languageName: unknown
   linkType: soft
 
@@ -32,14 +32,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-xml-parser@npm:^5.2.5":
-  version: 5.2.5
-  resolution: "fast-xml-parser@npm:5.2.5"
+"fast-xml-builder@npm:^1.1.4":
+  version: 1.1.4
+  resolution: "fast-xml-builder@npm:1.1.4"
   dependencies:
-    strnum: "npm:^2.1.0"
+    path-expression-matcher: "npm:^1.1.3"
+  checksum: 10c0/d5dfc0660f7f886b9f42747e6aa1d5e16c090c804b322652f65a5d7ffb93aa00153c3e1276cd053629f9f4c4f625131dc6886677394f7048e827e63b97b18927
+  languageName: node
+  linkType: hard
+
+"fast-xml-parser@npm:^5.5.6":
+  version: 5.5.6
+  resolution: "fast-xml-parser@npm:5.5.6"
+  dependencies:
+    fast-xml-builder: "npm:^1.1.4"
+    path-expression-matcher: "npm:^1.1.3"
+    strnum: "npm:^2.1.2"
   bin:
     fxparser: src/cli/cli.js
-  checksum: 10c0/d1057d2e790c327ccfc42b872b91786a4912a152d44f9507bf053f800102dfb07ece3da0a86b33ff6a0caa5a5cad86da3326744f6ae5efb0c6c571d754fe48cd
+  checksum: 10c0/b7aed4f561f57fe4eba91c5e4a4438cb7eb09ac885b32d912eec257b84e6587dea88a7afd5738fd36c1e6a0bce778dfd8fcefea829fcc44ef019753b92e36402
   languageName: node
   linkType: hard
 
@@ -50,6 +61,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"path-expression-matcher@npm:^1.1.3":
+  version: 1.1.3
+  resolution: "path-expression-matcher@npm:1.1.3"
+  checksum: 10c0/45c01471bc62c5f38d069418aec831763e6f45bb85f9520b08de441e6cd14f84b3098ecb66255e819c2af21102abcd2b45550dc1285996717ce9292802df2bc5
+  languageName: node
+  linkType: hard
+
 "platform@npm:^1.3.3":
   version: 1.3.6
   resolution: "platform@npm:1.3.6"
@@ -57,9 +75,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"strnum@npm:^2.1.0":
-  version: 2.1.1
-  resolution: "strnum@npm:2.1.1"
-  checksum: 10c0/1f9bd1f9b4c68333f25c2b1f498ea529189f060cd50aa59f1876139c994d817056de3ce57c12c970f80568d75df2289725e218bd9e3cdf73cd1a876c9c102733
+"strnum@npm:^2.1.2":
+  version: 2.2.0
+  resolution: "strnum@npm:2.2.0"
+  checksum: 10c0/9a656f5048047abff8d10d0bb57761a01916e368a71e95d4f5a962b57f64b738e20672e68ba10b7de3dc78e861c77bc0566bdeed7017abdda1caf0303c929a3f
   languageName: node
   linkType: hard


### PR DESCRIPTION
The `@xmldom/xmldom@0.8.x` (and other dependencies) did not have any updates in last six months
https://npmx.dev/package/@xmldom/xmldom